### PR TITLE
Implement average grade calculation and team retrieval

### DIFF
--- a/src/main/java/api/MongoGradeDataBase.java
+++ b/src/main/java/api/MongoGradeDataBase.java
@@ -268,6 +268,35 @@ public class MongoGradeDataBase implements GradeDataBase {
         // HINT 1: Look at the formTeam method to get an idea on how to parse the response
         // HINT 2: You may find it useful to just initially print the contents of the JSON
         //         then work on the details of how to parse it.
-        return null;
+        try {
+            response = client.newCall(request).execute();
+            responseBody = new JSONObject(response.body().string());
+
+            if (responseBody.getInt(STATUS_CODE) == SUCCESS_CODE) {
+                if (!responseBody.has("team") || responseBody.isNull("team")) {
+                    return null;
+                }
+                final JSONObject teamJson = responseBody.getJSONObject("team");
+                final JSONArray membersArray = teamJson.getJSONArray("members");
+                final String[] members = new String[membersArray.length()];
+                for (int i = 0; i < membersArray.length(); i++) {
+                    members[i] = membersArray.getString(i);
+                }
+
+                return Team.builder()
+                        .name(teamJson.getString(NAME))
+                        .members(members)
+                        .build();
+            }
+            else {
+                if (responseBody.has(MESSAGE)) {
+                    throw new RuntimeException(responseBody.getString(MESSAGE));
+                }
+                throw new RuntimeException("Failed to fetch team information");
+            }
+        }
+        catch (IOException | JSONException event) {
+            throw new RuntimeException(event);
+        }
     }
 }

--- a/src/main/java/usecase/GetAverageGradeUseCase.java
+++ b/src/main/java/usecase/GetAverageGradeUseCase.java
@@ -29,6 +29,24 @@ public final class GetAverageGradeUseCase {
         // TODO Task 3a: Complete the logic of calculating the average course grade for
         //              your team members. Hint: the getGrades method might be useful.
 
+        if (team == null || team.getMembers() == null) {
+            return 0;
+        }
+
+        for (String username : team.getMembers()) {
+            final Grade[] grades = gradeDataBase.getGrades(username);
+            if (grades == null) {
+                continue;
+            }
+
+            for (Grade grade : grades) {
+                if (grade != null && course.equals(grade.getCourse())) {
+                    sum += grade.getGrade();
+                    count++;
+                }
+            }
+        }
+
         if (count == 0) {
             return 0;
         }


### PR DESCRIPTION
## Summary
- compute the team average calculation logic in `GetAverageGradeUseCase`
- implement the MongoDB-backed `getMyTeam` API call to fetch and parse team membership

## Testing
- `mvn -q test` *(fails: unable to download maven-resources-plugin due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e539fc002c833296835f4811203835